### PR TITLE
fix: missing include in utility.h

### DIFF
--- a/src/utils/utility.h
+++ b/src/utils/utility.h
@@ -13,6 +13,7 @@
 #include <span>
 #include <vector>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <iomanip>
 


### PR DESCRIPTION
Building the project fails due to the missing `<memory>` header. This should allow building the project.

Closes #1 